### PR TITLE
Add #107 Feature Request "set loop to selection"

### DIFF
--- a/src/ppui/Menu.h
+++ b/src/ppui/Menu.h
@@ -46,6 +46,7 @@ enum MenuCommandIDs
 	MenuCommandIDPaste			= 3,
 	MenuCommandIDSelectAll		= 4,
 	MenuCommandIDSelectNothing	= 5,
+	MenuCommandIDLoopRange		= 6,
 	MenuCommandIDUndo			= 7,
 	MenuCommandIDRedo			= 8,
 	MenuCommandIDHide			= 0x10000

--- a/src/tracker/SampleEditor.cpp
+++ b/src/tracker/SampleEditor.cpp
@@ -444,6 +444,26 @@ void SampleEditor::selectAll()
 	selectionEnd = sample->samplen;
 }
 
+void SampleEditor::loopRange()
+{
+	if (!hasValidSelection())
+		return;
+
+	// If a loop type is not enabled, set loop to Forward.
+	// - Changes loop type to Forward when loop type is set to One shot
+	// 	 and the start of the selection is not at the start of the sample, 
+	// 	 but so does dragging the start of the loop. 
+	if (!getLoopType())
+		setLoopType(1);
+
+	// Once loop is enabled, set the loop start/end points to selection start/end points.
+	setRepeatStart(getSelectionStart());
+	setRepeatEnd(getSelectionEnd());
+
+	// Doesn't currently have undo or have the sample do the new loop 
+	// until it retriggers, but neither does dragging the loop points.
+}
+
 bool SampleEditor::validate()
 {
 	if (isEmptySample())

--- a/src/tracker/SampleEditor.h
+++ b/src/tracker/SampleEditor.h
@@ -184,7 +184,8 @@ public:
 	bool hasValidSelection() const { return ((selectionStart >= 0 && selectionEnd >= 0) && (selectionStart != selectionEnd)); }
 	
 	void selectAll();
-	
+	void loopRange();
+
 	bool validate();
 
 	// --- Multilevel UNDO / REDO --------------------------------------------

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -168,6 +168,7 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	editMenuControl->addEntry("Paste", MenuCommandIDPaste);
 	editMenuControl->addEntry("Crop", MenuCommandIDCrop);
 	editMenuControl->addEntry("Range all", MenuCommandIDSelectAll);
+	editMenuControl->addEntry("Loop range", MenuCommandIDLoopRange);
 	editMenuControl->addEntry(seperatorStringMed, -1);
 	editMenuControl->addEntry("Advanced   \x10", 0xFFFF, subMenuAdvanced);
 	editMenuControl->addEntry("Ext. Paste \x10", 0xFFFF, subMenuXPaste);
@@ -1437,6 +1438,14 @@ void SampleEditorControl::rangeAll(bool updateNotify/* = false*/)
 		notifyUpdate();
 }
 
+void SampleEditorControl::loopRange(bool updateNotify/* = false*/)
+{	
+	sampleEditor->loopRange();
+
+	if (updateNotify)
+		notifyUpdate();
+}
+
 void SampleEditorControl::rangeClear(bool updateNotify/* = false*/)
 {
 	sampleEditor->resetSelection();
@@ -1664,6 +1673,7 @@ void SampleEditorControl::invokeContextMenu(const PPPoint& p, bool translatePoin
 	editMenuControl->setState(MenuCommandIDCut, !hasValidSelection());
 	editMenuControl->setState(MenuCommandIDCrop, !hasValidSelection());
 	editMenuControl->setState(MenuCommandIDSelectAll, isEmptySample);
+	editMenuControl->setState(MenuCommandIDLoopRange, !hasValidSelection());
 	
 	// update submenu states
 	subMenuAdvanced->setState(MenuCommandIDNormalize, isEmptySample);
@@ -1770,6 +1780,11 @@ void SampleEditorControl::executeMenuCommand(pp_int32 commandId)
 			rangeAll(true);
 			break;
 					
+		// set loop to current selection
+		case MenuCommandIDLoopRange:
+			loopRange(true);
+			break;	
+
 		// Invoke tools
 		case MenuCommandIDNew:
 			invokeToolParameterDialog(ToolHandlerResponder::SampleToolTypeNew);

--- a/src/tracker/SampleEditorControl.h
+++ b/src/tracker/SampleEditorControl.h
@@ -161,6 +161,7 @@ public:
 	void showRange();
 	void rangeAll(bool updateNotify = false);
 	void rangeClear(bool updateNotify = false);
+	void loopRange(bool updateNotify = false); // set loop points to current range
 
 	void increaseRangeStart();
 	void decreaseRangeStart();


### PR DESCRIPTION
(Duplicated from the original pull request description #233 on milkytracker/MilkyTracker)

Added a right click menu option to the sample editor that sets the loop to the selection range as requested in #107.

It sets the loop type to Forward if there's no other loop type, and uses the existing loop type if set (unless loop type is One shot and the selection start isn't at the very beginning, similar to dragging the start loop point).

![image](https://user-images.githubusercontent.com/67843601/117609053-809e7100-b11c-11eb-90c4-883977031a19.png)

![image](https://user-images.githubusercontent.com/67843601/117609063-8431f800-b11c-11eb-9f41-f59fc876e9c0.png)



