### PR TITLE
Fix vertical scrollbar buttons

### DIFF
--- a/src/ppui/Scrollbar.cpp
+++ b/src/ppui/Scrollbar.cpp
@@ -518,7 +518,7 @@ pp_int32 PPScrollbar::handleEvent(PPObject* sender, PPEvent* event)
 		)
 	{
 		// Call parent event listener
-		PPEvent e(eBarScrollUp);
+		PPEvent e(eBarScrollUp, 1); //metaData=1 for scrolling with the scrollbar buttons
 		return eventListener->handleEvent(reinterpret_cast<PPObject*>(this), &e);
 	}
 	if (
@@ -533,7 +533,7 @@ pp_int32 PPScrollbar::handleEvent(PPObject* sender, PPEvent* event)
 		)
 	{
 		// Call parent event listener
-		PPEvent e(eBarScrollDown);
+		PPEvent e(eBarScrollDown, 1); //metaData=1 for scrolling with the scrollbar buttons
 		return eventListener->handleEvent(reinterpret_cast<PPObject*>(this), &e);
 	}
 	else if (/*event->getID() == eLMouseDown &&*/


### PR DESCRIPTION
Copied from my pull request (254) and issue comment (253):

Added a metaData of 1 to pass to with eBarScrollUp and eBarScrollDown events, so that when you click the up or down buttons in a scrollbar being used by another widget it scrolls 1 line at a time, instead of 0.

---

OS: Ubuntu 21.04
Milkytracker versions: 1.03, latest Github source build
Issue: When clicking the up/down buttons on a vertical scrollbar in any widget using a vertical scrollbar, nothing happens. Horizontal scrollbar buttons, as well as other ways of scrolling vertical scrollbars work.


After taking a look at it (in ListBox.cpp, etc.), it seems that the reason this happens is vertical scrolling uses `event->getMetaData` for determining how much to scroll when the buttons are clicked, and horizontal scrolling doesn't.

Scrolling events like mousewheel movements seem to provide their own changes to metaData, so they're not affected by the default of 0 - scrolling with the mousewheel changed it to 3 when I checked.

Since the `metaData` of an Event defaults to 0 if it doesn't provide anything, it passes that along when you click the up/down buttons, meaning you scroll 0 lines. Therefore, if we provide a 1 value for it to pass in each of the functions in Scrollbar.cpp i.e. `PPEvent e(eBarScrollUp, 1);` it passes that when you click the button instead of 0, meaning vertical scrolling with the buttons works everywhere that looks for `metaData`. 